### PR TITLE
Update W3C logo URL.

### DIFF
--- a/boilerplate/act-rules-format/logo.include
+++ b/boilerplate/act-rules-format/logo.include
@@ -1,1 +1,1 @@
-<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" /></a>
+<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72" /></a>

--- a/boilerplate/audiowg/logo.include
+++ b/boilerplate/audiowg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/dap/logo.include
+++ b/boilerplate/dap/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/fxtf/logo.include
+++ b/boilerplate/fxtf/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/geolocation/logo.include
+++ b/boilerplate/geolocation/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/gpuwg/logo.include
+++ b/boilerplate/gpuwg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-  <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+  <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/html/logo.include
+++ b/boilerplate/html/logo.include
@@ -1,1 +1,1 @@
-<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" /></a>
+<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72" /></a>

--- a/boilerplate/i18n/logo.include
+++ b/boilerplate/i18n/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/immersivewebwg/logo.include
+++ b/boilerplate/immersivewebwg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/mediacapture/logo.include
+++ b/boilerplate/mediacapture/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/mediawg/logo.include
+++ b/boilerplate/mediawg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/ricg/logo.include
+++ b/boilerplate/ricg/logo.include
@@ -2,5 +2,5 @@
 	<img src="https://raw.github.com/ResponsiveImagesCG/meta/master/logo/Web/RICG_logo_small.png" alt="Responsive Images Community Group" height=49>
 </a>
 <a href="https://www.w3.org/" class=logo-w3c>
-	<img src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" alt="W3C" height=48>
+	<img src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" alt="W3C" height=48>
 </a>

--- a/boilerplate/secondscreenwg/logo.include
+++ b/boilerplate/secondscreenwg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/serviceworkers/logo.include
+++ b/boilerplate/serviceworkers/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/svg/logo.include
+++ b/boilerplate/svg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/texttracks/logo.include
+++ b/boilerplate/texttracks/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/uievents/logo.include
+++ b/boilerplate/uievents/logo.include
@@ -1,1 +1,1 @@
-<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" /></a>
+<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72" /></a>

--- a/boilerplate/w3c/logo.include
+++ b/boilerplate/w3c/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/wasm/logo.include
+++ b/boilerplate/wasm/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/web-payments/logo.include
+++ b/boilerplate/web-payments/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webapps/logo.include
+++ b/boilerplate/webapps/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webappsec/logo.include
+++ b/boilerplate/webappsec/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webauthn/logo.include
+++ b/boilerplate/webauthn/logo.include
@@ -1,1 +1,1 @@
-<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" /></a>
+<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72" /></a>

--- a/boilerplate/webediting/logo.include
+++ b/boilerplate/webediting/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webfontswg/logo.include
+++ b/boilerplate/webfontswg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webmlwg/logo.include
+++ b/boilerplate/webmlwg/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webperf/logo.include
+++ b/boilerplate/webperf/logo.include
@@ -1,1 +1,1 @@
-<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72" /></a>
+<a href="https://www.w3.org/"><img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72" /></a>

--- a/boilerplate/webplatform/logo.include
+++ b/boilerplate/webplatform/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webrtc/logo.include
+++ b/boilerplate/webrtc/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>

--- a/boilerplate/webtransport/logo.include
+++ b/boilerplate/webtransport/logo.include
@@ -1,3 +1,3 @@
 <a href="https://www.w3.org/" class="logo">
-    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2016/logos/W3C" width="72">
+    <img alt="W3C" height="48" src="https://www.w3.org/StyleSheets/TR/2021/logos/W3C" width="72">
 </a>


### PR DESCRIPTION
This updates the URL of the W3C logo image to the one required by the
pubrules checker https://www.w3.org/pubrules/