### PR TITLE
Use [W3C-STYLESHEET-URL] for svg/header.include.

### DIFF
--- a/boilerplate/svg/header.include
+++ b/boilerplate/svg/header.include
@@ -5,7 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
   <title>[TITLE]</title>
   <link href="../default.css" rel=stylesheet type="text/css">
-  <link href="https://www.w3.org/StyleSheets/TR/W3C-[STATUS]" rel=stylesheet type="text/css">
+  <link href="[W3C-STYLESHEET-URL]" rel=stylesheet type="text/css">
 </head>
 <body class="h-entry">
 <div class="head">


### PR DESCRIPTION
This was the only header constructing the W3C stylesheet URL manually
rather than using W3C-STYLESHEET-URL.