### PR TITLE
Change profile-and-date id to w3c-state id.

### DIFF
--- a/boilerplate/act-rules-format/header.include
+++ b/boilerplate/act-rules-format/header.include
@@ -12,8 +12,8 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+    <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   </header>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/act-rules-format/header.include
+++ b/boilerplate/act-rules-format/header.include
@@ -12,7 +12,7 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
       <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   </header>
   <div data-fill-with="spec-metadata"></div>

--- a/boilerplate/aom/header-FD.include
+++ b/boilerplate/aom/header-FD.include
@@ -12,8 +12,8 @@
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
   <h2 id="subtitle" class="p-name no-num no-toc no-ref">[SPECVERSION?]</h2>
-  <h3 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h3>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/aom/header-FD.include
+++ b/boilerplate/aom/header-FD.include
@@ -12,7 +12,7 @@
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
   <h2 id="subtitle" class="p-name no-num no-toc no-ref">[SPECVERSION?]</h2>
-  <h3 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h3 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h3>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/audiowg/header-ED.include
+++ b/boilerplate/audiowg/header-ED.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/audiowg/header-ED.include
+++ b/boilerplate/audiowg/header-ED.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/audiowg/header.include
+++ b/boilerplate/audiowg/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/audiowg/header.include
+++ b/boilerplate/audiowg/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/browser-testing-tools/header.include
+++ b/boilerplate/browser-testing-tools/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/browser-testing-tools/header.include
+++ b/boilerplate/browser-testing-tools/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/csswg/header.include
+++ b/boilerplate/csswg/header.include
@@ -15,7 +15,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <details include-if="ED">
     <summary>Specification Metadata</summary>

--- a/boilerplate/csswg/header.include
+++ b/boilerplate/csswg/header.include
@@ -15,8 +15,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <details include-if="ED">
     <summary>Specification Metadata</summary>
     <div data-fill-with="spec-metadata"></div>

--- a/boilerplate/dap/header-ED.include
+++ b/boilerplate/dap/header-ED.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/dap/header-ED.include
+++ b/boilerplate/dap/header-ED.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/dap/header.include
+++ b/boilerplate/dap/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/dap/header.include
+++ b/boilerplate/dap/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/fxtf/header.include
+++ b/boilerplate/fxtf/header.include
@@ -15,8 +15,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/fxtf/header.include
+++ b/boilerplate/fxtf/header.include
@@ -15,7 +15,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/geolocation/header.include
+++ b/boilerplate/geolocation/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/geolocation/header.include
+++ b/boilerplate/geolocation/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/gpuwg/header.include
+++ b/boilerplate/gpuwg/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/gpuwg/header.include
+++ b/boilerplate/gpuwg/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/header.include
+++ b/boilerplate/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/header.include
+++ b/boilerplate/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/html/header.include
+++ b/boilerplate/html/header.include
@@ -13,8 +13,8 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+    <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   </header>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/html/header.include
+++ b/boilerplate/html/header.include
@@ -13,7 +13,7 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-    <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
       <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   </header>
   <div data-fill-with="spec-metadata"></div>

--- a/boilerplate/httpslocal/header.include
+++ b/boilerplate/httpslocal/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/httpslocal/header.include
+++ b/boilerplate/httpslocal/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/i18n/header.include
+++ b/boilerplate/i18n/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/i18n/header.include
+++ b/boilerplate/i18n/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/immersivewebwg/header.include
+++ b/boilerplate/immersivewebwg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/immersivewebwg/header.include
+++ b/boilerplate/immersivewebwg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/mediacapture/header-ED.include
+++ b/boilerplate/mediacapture/header-ED.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/mediacapture/header-ED.include
+++ b/boilerplate/mediacapture/header-ED.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/mediacapture/header.include
+++ b/boilerplate/mediacapture/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/mediacapture/header.include
+++ b/boilerplate/mediacapture/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/mediawg/header.include
+++ b/boilerplate/mediawg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/mediawg/header.include
+++ b/boilerplate/mediawg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/ping/header.include
+++ b/boilerplate/ping/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/ping/header.include
+++ b/boilerplate/ping/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/processcg/header.include
+++ b/boilerplate/processcg/header.include
@@ -14,8 +14,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/processcg/header.include
+++ b/boilerplate/processcg/header.include
@@ -14,7 +14,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/ricg/header.include
+++ b/boilerplate/ricg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/ricg/header.include
+++ b/boilerplate/ricg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/sacg/header.include
+++ b/boilerplate/sacg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/sacg/header.include
+++ b/boilerplate/sacg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/secondscreencg/header.include
+++ b/boilerplate/secondscreencg/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/secondscreencg/header.include
+++ b/boilerplate/secondscreencg/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/secondscreenwg/header.include
+++ b/boilerplate/secondscreenwg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/secondscreenwg/header.include
+++ b/boilerplate/secondscreenwg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/serviceworkers/header.include
+++ b/boilerplate/serviceworkers/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/serviceworkers/header.include
+++ b/boilerplate/serviceworkers/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/stylesheet.include
+++ b/boilerplate/stylesheet.include
@@ -364,7 +364,7 @@
 
 	h1 + h2,
 	#w3c-state {
-		/* #w3c-state is a subtitle in an H2 under the H1 */
+		/* #w3c-state is a subtitle in a P under the H1 */
 		margin-top: 0;
 	}
 	h2 + h3,

--- a/boilerplate/stylesheet.include
+++ b/boilerplate/stylesheet.include
@@ -363,8 +363,8 @@
 /** Subheadings ***************************************************************/
 
 	h1 + h2,
-	#profile-and-date {
-		/* #profile-and-date is a subtitle in an H2 under the H1 */
+	#w3c-state {
+		/* #w3c-state is a subtitle in an H2 under the H1 */
 		margin-top: 0;
 	}
 	h2 + h3,

--- a/boilerplate/svg/header.include
+++ b/boilerplate/svg/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/svg/header.include
+++ b/boilerplate/svg/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/tag/header-WG-NOTE.include
+++ b/boilerplate/tag/header-WG-NOTE.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/tag/header-WG-NOTE.include
+++ b/boilerplate/tag/header-WG-NOTE.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/tag/header.include
+++ b/boilerplate/tag/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/tag/header.include
+++ b/boilerplate/tag/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/tc39/header.include
+++ b/boilerplate/tc39/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <hr title="Separator for header">

--- a/boilerplate/tc39/header.include
+++ b/boilerplate/tc39/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/test/header.include
+++ b/boilerplate/test/header.include
@@ -9,8 +9,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/test/header.include
+++ b/boilerplate/test/header.include
@@ -9,7 +9,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/texttracks/header-CG-DRAFT.include
+++ b/boilerplate/texttracks/header-CG-DRAFT.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/texttracks/header-CG-DRAFT.include
+++ b/boilerplate/texttracks/header-CG-DRAFT.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/texttracks/header.include
+++ b/boilerplate/texttracks/header.include
@@ -40,8 +40,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS]
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS]
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/texttracks/header.include
+++ b/boilerplate/texttracks/header.include
@@ -40,7 +40,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS]
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS]
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/uievents/header.include
+++ b/boilerplate/uievents/header.include
@@ -15,8 +15,8 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+    <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   </header>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/uievents/header.include
+++ b/boilerplate/uievents/header.include
@@ -15,7 +15,7 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
       <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   </header>
   <div data-fill-with="spec-metadata"></div>

--- a/boilerplate/w3c/header.include
+++ b/boilerplate/w3c/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/w3c/header.include
+++ b/boilerplate/w3c/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/wasm/header.include
+++ b/boilerplate/wasm/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/wasm/header.include
+++ b/boilerplate/wasm/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/web-bluetooth-cg/header.include
+++ b/boilerplate/web-bluetooth-cg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/web-bluetooth-cg/header.include
+++ b/boilerplate/web-bluetooth-cg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/web-payments/header.include
+++ b/boilerplate/web-payments/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/web-payments/header.include
+++ b/boilerplate/web-payments/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webapps/header.include
+++ b/boilerplate/webapps/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webapps/header.include
+++ b/boilerplate/webapps/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webappsec/header-ED.include
+++ b/boilerplate/webappsec/header-ED.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <details>
     <summary>Specification Metadata</summary>
     <div data-fill-with="spec-metadata"></div>

--- a/boilerplate/webappsec/header-ED.include
+++ b/boilerplate/webappsec/header-ED.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <details>
     <summary>Specification Metadata</summary>

--- a/boilerplate/webappsec/header.include
+++ b/boilerplate/webappsec/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webappsec/header.include
+++ b/boilerplate/webappsec/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webauthn/header.include
+++ b/boilerplate/webauthn/header.include
@@ -12,8 +12,8 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+    <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+      <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   </header>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webauthn/header.include
+++ b/boilerplate/webauthn/header.include
@@ -12,7 +12,7 @@
   <header>
     <p data-fill-with="logo"></p>
     <h1 id="title" class="p-name no-ref">[TITLE] [LEVEL]</h1>
-    <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
       <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   </header>
   <div data-fill-with="spec-metadata"></div>

--- a/boilerplate/webediting/header.include
+++ b/boilerplate/webediting/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webediting/header.include
+++ b/boilerplate/webediting/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webfontswg/header-ED.include
+++ b/boilerplate/webfontswg/header-ED.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webfontswg/header-ED.include
+++ b/boilerplate/webfontswg/header-ED.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webfontswg/header.include
+++ b/boilerplate/webfontswg/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webfontswg/header.include
+++ b/boilerplate/webfontswg/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webgl/header.include
+++ b/boilerplate/webgl/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webgl/header.include
+++ b/boilerplate/webgl/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webgpu/header.include
+++ b/boilerplate/webgpu/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webgpu/header.include
+++ b/boilerplate/webgpu/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webml/header.include
+++ b/boilerplate/webml/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webml/header.include
+++ b/boilerplate/webml/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webmlwg/header.include
+++ b/boilerplate/webmlwg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webmlwg/header.include
+++ b/boilerplate/webmlwg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webplatform/header.include
+++ b/boilerplate/webplatform/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webplatform/header.include
+++ b/boilerplate/webplatform/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webrtc/header-ED.include
+++ b/boilerplate/webrtc/header-ED.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webrtc/header-ED.include
+++ b/boilerplate/webrtc/header-ED.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webrtc/header.include
+++ b/boilerplate/webrtc/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webrtc/header.include
+++ b/boilerplate/webrtc/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webtransport/header-ED.include
+++ b/boilerplate/webtransport/header-ED.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webtransport/header-ED.include
+++ b/boilerplate/webtransport/header-ED.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webtransport/header.include
+++ b/boilerplate/webtransport/header.include
@@ -12,7 +12,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webtransport/header.include
+++ b/boilerplate/webtransport/header.include
@@ -12,8 +12,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/webvr/header.include
+++ b/boilerplate/webvr/header.include
@@ -11,7 +11,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/webvr/header.include
+++ b/boilerplate/webvr/header.include
@@ -11,8 +11,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/wecg/header.include
+++ b/boilerplate/wecg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/wecg/header.include
+++ b/boilerplate/wecg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>

--- a/boilerplate/wg14/header.include
+++ b/boilerplate/wg14/header.include
@@ -26,8 +26,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">N[SHORTNAME]<br>[SPECTITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <hr title="Separator for header">

--- a/boilerplate/wg14/header.include
+++ b/boilerplate/wg14/header.include
@@ -26,7 +26,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">N[SHORTNAME]<br>[SPECTITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/wg21/header.include
+++ b/boilerplate/wg21/header.include
@@ -84,8 +84,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[SHORTNAME]R[LEVEL]<br>[SPECTITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <hr title="Separator for header">

--- a/boilerplate/wg21/header.include
+++ b/boilerplate/wg21/header.include
@@ -84,7 +84,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[SHORTNAME]R[LEVEL]<br>[SPECTITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[ISODATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/whatwg/header-RD.include
+++ b/boilerplate/whatwg/header-RD.include
@@ -15,7 +15,7 @@
   </a>
   <hgroup>
     <h1 id="title" class="p-name no-ref">[SPECTITLE]</h1>
-    <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS] — Published <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS] — Published <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   </hgroup>
   <details class="annoying-warning" open>
     <summary>This is a Review Draft of the standard</summary>

--- a/boilerplate/whatwg/header-RD.include
+++ b/boilerplate/whatwg/header-RD.include
@@ -15,7 +15,7 @@
   </a>
   <hgroup>
     <h1 id="title" class="p-name no-ref">[SPECTITLE]</h1>
-    <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS] — Published <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+    <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS] — Published <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   </hgroup>
   <details class="annoying-warning" open>
     <summary>This is a Review Draft of the standard</summary>

--- a/boilerplate/wicg/header.include
+++ b/boilerplate/wicg/header.include
@@ -10,7 +10,7 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="profile-and-date" class="no-num no-toc no-ref">[LONGSTATUS],
+  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
     <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>

--- a/boilerplate/wicg/header.include
+++ b/boilerplate/wicg/header.include
@@ -10,8 +10,8 @@
 <div class="head">
   <p data-fill-with="logo"></p>
   <h1 id="title" class="p-name no-ref">[TITLE]</h1>
-  <h2 id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
-    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></h2>
+  <p id="w3c-state" class="no-num no-toc no-ref">[LONGSTATUS],
+    <time class="dt-updated" datetime="[ISODATE]">[DATE]</time></p>
   <div data-fill-with="spec-metadata"></div>
   <div data-fill-with="warning"></div>
   <p class='copyright' data-fill-with='copyright'></p>


### PR DESCRIPTION
Having the w3c-state id is a requirement of specberus and is currently
required for Echidna publishing.  See the recent failure logs in
https://lists.w3.org/Archives/Public/public-tr-notifications/2021Nov/