### PR TITLE
Remove trailing slash from homepage link to pass Specberus checker

### DIFF
--- a/boilerplate/webmlwg/status-ED.include
+++ b/boilerplate/webmlwg/status-ED.include
@@ -6,7 +6,7 @@
     reports index</a> at http://www.w3.org/TR/.</em>
   </p>
   <p>
-    This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning/">Web Machine Learning Working Group</a>
+    This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a>
     as an Editors' Draft. This document is intended to become a W3C Recommendation.
 
     Feedback and comments on this specification are welcome. Please use

--- a/boilerplate/webmlwg/status-FPWD.include
+++ b/boilerplate/webmlwg/status-FPWD.include
@@ -9,7 +9,7 @@
         </p>
 
         <p>
-            This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning/">Web Machine Learning Working Group</a> as a Working Draft using the <a
+            This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a> as a Working Draft using the <a
       href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>

--- a/boilerplate/webmlwg/status-WD.include
+++ b/boilerplate/webmlwg/status-WD.include
@@ -9,7 +9,7 @@
         </p>
 
         <p>
-            This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning/">Web Machine Learning Working Group</a> as a Working Draft using the <a
+            This document was published by the <a href="https://www.w3.org/groups/wg/webmachinelearning">Web Machine Learning Working Group</a> as a Working Draft using the <a
       href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
       track</a>. This document is intended to become a <abbr title="World Wide Web Consortium">W3C</abbr> Recommendation.
         </p>


### PR DESCRIPTION
Specberus "no-homepage-link" error details:
https://labs.w3.org/echidna/api/status?id=ac62262d-85d0-4dc7-8104-4251dad3904a

Regression probably introduced in:
https://github.com/w3c/specberus/pull/1366