### PR TITLE
Prevent pubrules error on FPWD

### DIFF
--- a/boilerplate/csswg/status.include
+++ b/boilerplate/csswg/status.include
@@ -75,7 +75,7 @@
 	as a <strong>First Public Working Draft</strong> using the <a
       href='https://www.w3.org/2021/Process-20211102/#recs-and-notes'>Recommendation
       track</a>.
-	Publication as a Working Draft
+	Publication as a First Public Working Draft
 	does not imply endorsement by <abbr title="World Wide Web Consortium">W3C</abbr> and its Members.
 
 <p include-if="WD, FPWD, CRD">


### PR DESCRIPTION
It has to be First Public Working Draft in both places