### PR TITLE
Use the new IPR pages

### DIFF
--- a/boilerplate/audiowg/status-CR.include
+++ b/boilerplate/audiowg/status-CR.include
@@ -32,7 +32,7 @@
 <p>
 	This document was produced by a group operating under
 	the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/46884/status" rel=disclosure>public list of any patent disclosures</a>
+	W3C maintains a <a href="https://www.w3.org/groups/wg/audio/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/audiowg/status-ED.include
+++ b/boilerplate/audiowg/status-ED.include
@@ -20,7 +20,7 @@
 <p>
   This document was produced by groups operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/46884/status" rel="disclosure">public list of any patent disclosures</a>
+  W3C maintains a <a href="https://www.w3.org/groups/wg/audio/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/audiowg/status-FPWD.include
+++ b/boilerplate/audiowg/status-FPWD.include
@@ -35,7 +35,7 @@
 <p>
   This document was produced by groups operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/46884/status" rel="disclosure">public list of any patent disclosures</a>
+  W3C maintains a <a href="https://www.w3.org/groups/wg/audio/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/audiowg/status-WD.include
+++ b/boilerplate/audiowg/status-WD.include
@@ -31,7 +31,7 @@
 <p>
   This document was produced by groups operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/46884/status" rel="disclosure">public list of any patent disclosures</a>
+  W3C maintains a <a href="https://www.w3.org/groups/wg/audio/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/csswg/status.include
+++ b/boilerplate/csswg/status.include
@@ -98,7 +98,7 @@
 <p exclude-if="ED">This document was produced by a group operating under the
 	<a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
 	W3C maintains a
-	<a rel="disclosure" href="https://www.w3.org/2004/01/pp-impl/32061/status">public list of any patent disclosures</a>
+	<a rel="disclosure" href="https://www.w3.org/groups/wg/css/ipr">public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes

--- a/boilerplate/fxtf/status-CR.include
+++ b/boilerplate/fxtf/status-CR.include
@@ -31,7 +31,7 @@
 <p>
 	This document was produced by a group operating under
 	the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a>
+	W3C maintains a <a href="https://www.w3.org/groups/wg/css/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/fxtf/status-ED.include
+++ b/boilerplate/fxtf/status-ED.include
@@ -19,7 +19,7 @@
 <p>
 	This document was produced by a group operating under
 	the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-	W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/32061/status" rel=disclosure>public list of any patent disclosures</a>
+	W3C maintains a <a href="https://www.w3.org/groups/wg/css/ipr" rel=disclosure>public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/fxtf/status-FPWD.include
+++ b/boilerplate/fxtf/status-FPWD.include
@@ -24,7 +24,7 @@
   <p>This document was produced by a group operating under the <a
    href="https://www.w3.org/Consortium/Patent-Policy-20200915/">
    W3C Patent Policy</a>. W3C maintains a <a
-   href="https://www.w3.org/2004/01/pp-impl/32061/status"
+   href="https://www.w3.org/groups/wg/css/ipr"
    rel=disclosure>public list of any patent disclosures</a> made in
    connection with the deliverables of the group; that page also includes
    instructions for disclosing a patent. An individual who has actual

--- a/boilerplate/fxtf/status-LCWD.include
+++ b/boilerplate/fxtf/status-LCWD.include
@@ -23,7 +23,7 @@
   <p>This document was produced by a group operating under the <a
    href="https://www.w3.org/Consortium/Patent-Policy-20200915/">
    W3C Patent Policy</a>. W3C maintains a <a
-   href="https://www.w3.org/2004/01/pp-impl/32061/status"
+   href="https://www.w3.org/groups/wg/css/ipr"
    rel=disclosure>public list of any patent disclosures</a> made in
    connection with the deliverables of the group; that page also includes
    instructions for disclosing a patent. An individual who has actual

--- a/boilerplate/fxtf/status-WD.include
+++ b/boilerplate/fxtf/status-WD.include
@@ -22,7 +22,7 @@
 
   <p>This document was produced by a group operating under the <a
    href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-   W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/32061/status"
+   W3C maintains a <a href="https://www.w3.org/groups/wg/css/ipr"
    rel=disclosure>public list of any patent disclosures</a> made in
    connection with the deliverables of the group; that page also includes
    instructions for disclosing a patent. An individual who has actual

--- a/boilerplate/houdini/status.include
+++ b/boilerplate/houdini/status.include
@@ -98,7 +98,7 @@
 <p exclude-if="ED">This document was produced by a group operating under the
 	<a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
 	W3C maintains a
-	<a rel="disclosure" href="https://www.w3.org/2004/01/pp-impl/32061/status">public list of any patent disclosures</a>
+	<a rel="disclosure" href="https://www.w3.org/groups/wg/css/ipr">public list of any patent disclosures</a>
 	made in connection with the deliverables of the group;
 	that page also includes instructions for disclosing a patent.
 	An individual who has actual knowledge of a patent which the individual believes

--- a/boilerplate/webfontswg/status-ED.include
+++ b/boilerplate/webfontswg/status-ED.include
@@ -16,7 +16,7 @@
 <p>
   This document was produced by groups operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a>
+  W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/webfontswg/status-FPWD.include
+++ b/boilerplate/webfontswg/status-FPWD.include
@@ -31,7 +31,7 @@
 <p>
   This document was produced by groups operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a>
+  W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>

--- a/boilerplate/webfontswg/status-WD.include
+++ b/boilerplate/webfontswg/status-WD.include
@@ -27,7 +27,7 @@
 <p>
   This document was produced by groups operating under
   the <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/">W3C Patent Policy</a>.
-  W3C maintains a <a href="https://www.w3.org/2004/01/pp-impl/44556/status" rel="disclosure">public list of any patent disclosures</a>
+  W3C maintains a <a href="https://www.w3.org/groups/wg/webfonts/ipr" rel="disclosure">public list of any patent disclosures</a>
   made in connection with the deliverables of the group;
   that page also includes instructions for disclosing a patent.
   An individual who has actual knowledge of a patent which the individual believes contains <a href="https://www.w3.org/Consortium/Patent-Policy-20200915/#def-essential">Essential Claim(s)</a>


### PR DESCRIPTION
The old `pp-impl` ones redirect to these now anyway, but better to directly link to the correct ones