### PR TITLE
Add explicit </p> tag before <wpt> to avoid generated markup error

### DIFF
--- a/boilerplate/csswg/footer.include
+++ b/boilerplate/csswg/footer.include
@@ -36,7 +36,7 @@ Document conventions</h3>
 
     <strong class="advisement">
         UAs MUST provide an accessible alternative.
-    </strong>
+    </strong></p>
 
     <wpt open title="Tests relating to the content of this specification
                      may be documented in “Tests” blocks like this one.

--- a/boilerplate/fxtf/footer-CR.include
+++ b/boilerplate/fxtf/footer-CR.include
@@ -35,7 +35,7 @@ Document conventions</h3>
 
     <strong class="advisement">
         UAs MUST provide an accessible alternative.
-    </strong>
+    </strong></p>
 
     <wpt open title="Tests relating to the content of this specification
                      may be documented in “Tests” blocks like this one.

--- a/boilerplate/fxtf/footer.include
+++ b/boilerplate/fxtf/footer.include
@@ -36,7 +36,7 @@ Document conventions</h3>
 
     <strong class="advisement">
         UAs MUST provide an accessible alternative.
-    </strong>
+    </strong></p>
 
     <wpt open title="Tests relating to the content of this specification
                      may be documented in “Tests” blocks like this one.

--- a/boilerplate/houdini/footer.include
+++ b/boilerplate/houdini/footer.include
@@ -36,7 +36,7 @@ Document conventions</h3>
 
     <strong class="advisement">
         UAs MUST provide an accessible alternative.
-    </strong>
+    </strong></p>
 
     <wpt open title="Tests relating to the content of this specification
                      may be documented in “Tests” blocks like this one.


### PR DESCRIPTION
See for example:

https://validator.w3.org/nu/?doc=https%3A%2F%2Fdrafts.csswg.org%2Fselectors%2F

> Error: No p element in scope but a p end tag seen.
>
> From line 4972, column 3; to line 4972, column 6
>
> `etails>↩  </p>↩  <h3`

The `<wpt>` in the template is converted into a `<details>`, but is still in a `<p>...</p>` so the paragraph gets implicitly closed by the `<details>` tag and then the `</p>` tag afterwards is an error.