### PR TITLE
fixed mail list link from CG to WG

### DIFF
--- a/boilerplate/immersivewebwg/defaults.include
+++ b/boilerplate/immersivewebwg/defaults.include
@@ -1,4 +1,4 @@
 {
-	"Mailing List Archives": "http://lists.w3.org/Archives/Public/public-immersive-web/",
+	"Mailing List Archives": "http://lists.w3.org/Archives/Public/public-immersive-web-wg/",
 	"Include Mdn Panels": "if possible"
 }

--- a/boilerplate/immersivewebwg/status-ED.include
+++ b/boilerplate/immersivewebwg/status-ED.include
@@ -12,7 +12,7 @@
     Feedback and comments on this specification are welcome. Please use
     <a href="[REPOSITORYURL]/issues">Github issues</a>.
     Discussions may also be found in the
-    <a href="http://lists.w3.org/Archives/Public/public-immersive-web/">public-immersive-web@w3.org archives</a>.
+    <a href="http://lists.w3.org/Archives/Public/public-immersive-web-wg/">public-immersive-web-wg@w3.org archives</a>.
   </p>
   <p>
     Publication as an Editors' Draft does not imply endorsement by


### PR DESCRIPTION
current URL in `immersivewebwg` files points to a mail list for CG but not WG. 
This PR is to replace links with WG one.